### PR TITLE
Update Unit.cs

### DIFF
--- a/Episode 10 - threading/Assets/Scripts/Unit.cs
+++ b/Episode 10 - threading/Assets/Scripts/Unit.cs
@@ -54,6 +54,8 @@ public class Unit : MonoBehaviour {
 		transform.LookAt (path.lookPoints [0]);
 
 		float speedPercent = 1;
+		
+		int pathHash = path.GetHashCode();
 
 		while (followingPath) {
 			Vector2 pos2D = new Vector2 (transform.position.x, transform.position.z);
@@ -82,6 +84,11 @@ public class Unit : MonoBehaviour {
 
 			yield return null;
 
+			// Check if the path has changed
+			if (path.GetHashCode() != pathHash) {
+				followingPath = false;
+			}
+			
 		}
 	}
 


### PR DESCRIPTION
BugFix for when the path changes but the coroutine runs until the next yield statement, causing an error to throw when the pathIndex on line 62 is bigger than what the new path's  turnBoundaries length. Checking with a hash means that at least *most* of the time this error doesn't come to pass, and is not resource intensive whatsoever on the method. The possibilities of having two paths with the same hash is something like 4.2 billion as is the number of int, so there is an eventual chance of collision. A more surefire method would probably be to add some kind of pathID to the Path class and check against that, but I'm not invested enough to figure that out yet. :)